### PR TITLE
Fix crash on kp analyzer

### DIFF
--- a/src/analyzer/morph.rs
+++ b/src/analyzer/morph.rs
@@ -124,4 +124,27 @@ mod tests {
         assert_eq!(RU.parse("минимальный").len(), 2);
         assert_eq!(RU.parse("менимальный").len(), 3);
     }
+
+    #[test]
+    fn parse_one_letter() {
+        assert_eq!(RU.parse("с").len(), 25);
+    }
+
+    #[test]
+    fn parse_one_letter_and_dot() {
+        assert_eq!(RU.parse("м.").len(), 1);
+    }
+
+    #[test]
+    fn parse_unknown_two_letter() {
+        assert_eq!(RU.parse("ТМ").len(), 1);
+        assert_eq!(RU.parse("КТ").len(), 1);
+        assert_eq!(RU.parse("1С").len(), 1);
+    }
+
+    #[test]
+    fn parse_dash() {
+        assert_eq!(RU.parse("Р-ка").len(), 1);
+        assert_eq!(RU.parse("з-то").len(), 1);
+    }
 }

--- a/src/analyzer/units/by_analogy/kp.rs
+++ b/src/analyzer/units/by_analogy/kp.rs
@@ -37,6 +37,11 @@ impl AnalyzerUnit for KnownPrefixAnalyzer {
         trace!("KnownPrefixAnalyzer::parse()");
         trace!(r#" word = "{}", word_lower = "{}" "#, word, word_lower);
 
+        // This analyzer only works on longer words
+        if word_lower.chars().count() < self.min_reminder_length {
+            return;
+        }
+
         for (prefix, unprefixed_word) in self.possible_splits(morph, word_lower) {
             'iter_parses: for parsed in morph.parse(unprefixed_word) {
                 let tag = parsed.lex.get_tag(morph);
@@ -84,7 +89,8 @@ impl KnownPrefixAnalyzer {
         word: &'s str,
     ) -> impl Iterator<Item = (&'s str, &'s str)> + 'i {
         let word_len = word.chars().count();
-        assert!(word_len >= self.min_reminder_length);
+        // This is checked in <Self as AnalyzedUnit>::parse
+        debug_assert!(word_len >= self.min_reminder_length);
         let limit = word_len - self.min_reminder_length;
         let word_prefixes = morph.dict.prediction_prefixes.sorted_prefixes(word);
         trace!("word_prefixes: {}", word_prefixes.join(", "));


### PR DESCRIPTION
The commit includes test which broke analyzer previously. These include
dots and dashes. However these things do work sometimes and sometimes
not.

I mean while I'm not sure I'm feeding the data correctly, but I think crash
is bad idea anyway.

The crash was:

```
thread 'main' panicked at 'assertion failed: word_len >= self.min_reminder_length', target/.cargo/git/checkouts/rsmorphy-16a9b60a66c15c48/a6d43b
2/src/analyzer/units/by_analogy/kp.rs:87:9
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:71
             at libstd/sys_common/backtrace.rs:59
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:211
   3: std::panicking::default_hook
             at libstd/panicking.rs:227
   4: std::panicking::rust_panic_with_hook
             at libstd/panicking.rs:511
   5: std::panicking::begin_panic
             at /checkout/src/libstd/panicking.rs:445
   6: <rsmorphy::analyzer::units::by_analogy::kp::KnownPrefixAnalyzer as rsmorphy::analyzer::units::abc::AnalyzerUnit>::parse
             at target/.cargo/git/checkouts/rsmorphy-16a9b60a66c15c48/a6d43b2/src/analyzer/units/by_analogy/kp.rs:87
             at target/.cargo/git/checkouts/rsmorphy-16a9b60a66c15c48/a6d43b2/src/analyzer/units/by_analogy/kp.rs:40
   7: rsmorphy::analyzer::morph::MorphAnalyzer::parse
             at target/.cargo/git/checkouts/rsmorphy-16a9b60a66c15c48/a6d43b2/src/analyzer/morph.rs:90
             at target/.cargo/git/checkouts/rsmorphy-16a9b60a66c15c48/a6d43b2/src/analyzer/morph.rs:100
   8: <rsmorphy::analyzer::units::by_hyphen::hsp::HyphenSeparatedParticleAnalyzer as rsmorphy::analyzer::units::abc::AnalyzerUnit>::parse
             at target/.cargo/git/checkouts/rsmorphy-16a9b60a66c15c48/a6d43b2/src/analyzer/units/by_hyphen/hsp.rs:56
   9: rsmorphy::analyzer::morph::MorphAnalyzer::parse
             at target/.cargo/git/checkouts/rsmorphy-16a9b60a66c15c48/a6d43b2/src/analyzer/morph.rs:84
             at target/.cargo/git/checkouts/rsmorphy-16a9b60a66c15c48/a6d43b2/src/analyzer/morph.rs:100
```